### PR TITLE
Added custom time property

### DIFF
--- a/src/components/timePicker.vue
+++ b/src/components/timePicker.vue
@@ -51,6 +51,7 @@ const emit = defineEmits<{
 
 const props = withDefaults(
   defineProps<{
+    customTime?: string | null;
     disabled?: boolean;
     min?: string;
     max?: string;
@@ -88,6 +89,10 @@ const setInputData = (value: string | null | Date) => {
     state.inputHour = value.getHours();
     state.inputMinute = value.getMinutes();
     state.inputSecond = value.getSeconds();
+  } else if (props.customTime != null) {
+    state.inputHour = parseInt(props.customTime.split(":")[0]);
+    state.inputMinute = parseInt(props.customTime.split(":")[1]);
+    state.inputSecond = parseInt(props.customTime.split(":")[2]);
   }
 };
 


### PR DESCRIPTION
Hi Matija,

I added a property where you can set a specific time by default to the timer. I did this because we experienced an issue wherein we placed the timepicker inside a v-menu tag from vuetify 3. Every time we click the activator for the timepicker, it rerenders the component, meaning the selected time values are reset.  Now the POs don't want this behavior, so yeah. 

You can merge it if you want. 

Cheers!