### PR TITLE
feat: add disabled specific hours, minutes, and seconds props

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,13 +1,13 @@
 <template>
   <div style="display: flex">
     <time-picker
-  v-model="time"
-  :disabled-hours="disabledHours"           
-  :disabled-minutes="disabledMinutes"
-  :disabled-seconds="disabledSeconds"
-  :use-seconds="true"
->
-</time-picker>
+      v-model="time"
+      :disabled-hours="disabledHours"
+      :disabled-minutes="disabledMinutes"
+      :disabled-seconds="disabledSeconds"
+      use-seconds
+    >
+    </time-picker>
 
     {{ time }}
   </div>
@@ -23,9 +23,9 @@ import timePicker from "./components/timePicker.vue";
 
 const time = ref<Date | null | string>(null);
 const hidden = ref(false);
-const disabledHours = ref([0,1,2,3,4,5,6,7,8,9,23]);
+const disabledHours = ref([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 23]);
 const disabledMinutes = ref([]);
-const disabledSeconds = ref([5,10]);
+const disabledSeconds = ref([5, 10]);
 
 const setVal = () => {
   time.value = "12:04:04";
@@ -47,9 +47,9 @@ const generateDisabledMinutes = () => {
     }
   }
   return disabledMinutes;
-}
+};
 
 onMounted(() => {
-  disabledMinutes.value = generateDisabledMinutes()
-})
+  disabledMinutes.value = generateDisabledMinutes();
+});
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,13 +2,13 @@
   <div style="display: flex">
     <time-picker
       v-model="time"
+      v-if="!hidden"
+      use-seconds
       :disabled-hours="disabledHours"
       :disabled-minutes="disabledMinutes"
       :disabled-seconds="disabledSeconds"
-      use-seconds
     >
     </time-picker>
-
     {{ time }}
   </div>
   <div style="display: flex">

--- a/src/App.vue
+++ b/src/App.vue
@@ -42,7 +42,7 @@ const changed = () => {
 const generateDisabledMinutes = () => {
   const disabledMinutes = [];
   for (let i = 0; i < 60; i++) {
-    if (i % 5 !== 0) {
+    if (i % 10 !== 0) {
       disabledMinutes.push(i);
     }
   }

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, computed } from "vue";
+import { ref, onMounted } from "vue";
 import timePicker from "./components/timePicker.vue";
 
 const time = ref<Date | null | string>(null);

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,14 @@
 <template>
   <div style="display: flex">
     <time-picker
-      @click:hour="changed"
-      v-model="time"
-      v-if="!hidden"
-      use-seconds
-    >
-    </time-picker>
+  v-model="time"
+  :disabled-hours="disabledHours"           
+  :disabled-minutes="disabledMinutes"
+  :disabled-seconds="disabledSeconds"
+  :use-seconds="true"
+>
+</time-picker>
+
     {{ time }}
   </div>
   <div style="display: flex">
@@ -16,11 +18,14 @@
 </template>
 
 <script lang="ts" setup>
-import { ref } from "vue";
+import { ref, onMounted, computed } from "vue";
 import timePicker from "./components/timePicker.vue";
 
 const time = ref<Date | null | string>(null);
 const hidden = ref(false);
+const disabledHours = ref([0,1,2,3,4,5,6,7,8,9,23]);
+const disabledMinutes = ref([]);
+const disabledSeconds = ref([5,10]);
 
 const setVal = () => {
   time.value = "12:04:04";
@@ -33,4 +38,18 @@ const hide = () => {
 const changed = () => {
   console.log("bruh");
 };
+
+const generateDisabledMinutes = () => {
+  const disabledMinutes = [];
+  for (let i = 0; i < 60; i++) {
+    if (i % 5 !== 0) {
+      disabledMinutes.push(i);
+    }
+  }
+  return disabledMinutes;
+}
+
+onMounted(() => {
+  disabledMinutes.value = generateDisabledMinutes()
+})
 </script>

--- a/src/components/timePicker.vue
+++ b/src/components/timePicker.vue
@@ -41,6 +41,7 @@
           ? state.inputMinute
           : state.inputSecond
       "
+      :disabled-values="disabledValues"
     />
   </div>
 </template>
@@ -78,6 +79,9 @@ const props = withDefaults(
     color?: string;
     modelValue: string | null | Date;
     width?: number | string;
+    disabledHours?: number[];
+    disabledMinutes?: number[];
+    disabledSeconds?: number[];
   }>(),
   {
     color: "#3ba13b",
@@ -210,4 +214,11 @@ watch(
   () => props.modelValue,
   (val) => setInputData(val)
 );
+
+const disabledValues = computed(() => {
+  if (state.selecting === SelectingTimes.Hour) return props.disabledHours || [];
+  if (state.selecting === SelectingTimes.Minute) return props.disabledMinutes || [];
+  if (state.selecting === SelectingTimes.Second) return props.disabledSeconds || [];
+  return [];
+});
 </script>

--- a/src/components/timePicker.vue
+++ b/src/components/timePicker.vue
@@ -85,7 +85,7 @@ const props = withDefaults(
   }>(),
   {
     color: "#3ba13b",
-    automatic: true
+    automatic: true,
   }
 );
 
@@ -96,7 +96,7 @@ const state = reactive({
   lazyInputHour: null as number | null,
   lazyInputMinute: null as number | null,
   lazyInputSecond: null as number | null,
-  selecting: SelectingTimes.Hour
+  selecting: SelectingTimes.Hour,
 });
 
 const setInputData = (value: string | null | Date) => {
@@ -117,7 +117,7 @@ const setInputData = (value: string | null | Date) => {
 };
 
 const styles = computed(() => ({
-  width: props.fullWidth ? undefined : convertToUnit(props.width || 290)
+  width: props.fullWidth ? undefined : convertToUnit(props.width || 290),
 }));
 
 const genValue = () => {
@@ -217,8 +217,10 @@ watch(
 
 const disabledValues = computed(() => {
   if (state.selecting === SelectingTimes.Hour) return props.disabledHours || [];
-  if (state.selecting === SelectingTimes.Minute) return props.disabledMinutes || [];
-  if (state.selecting === SelectingTimes.Second) return props.disabledSeconds || [];
+  if (state.selecting === SelectingTimes.Minute)
+    return props.disabledMinutes || [];
+  if (state.selecting === SelectingTimes.Second)
+    return props.disabledSeconds || [];
   return [];
 });
 </script>

--- a/src/components/timePickerClock.vue
+++ b/src/components/timePickerClock.vue
@@ -12,17 +12,17 @@
         @touchmove="onDragMove"
         class="time-picker-clock"
         :class="{
-          'time-picker-clock--indeterminate': value == null
+          'time-picker-clock--indeterminate': value == null,
         }"
       >
         <div ref="innerClock" class="time-picker-clock__inner">
           <div
             class="time-picker-clock__hand"
             :style="{
-              ...clockHandStyle
+              ...clockHandStyle,
             }"
             :class="{
-              'time-picker-clock__hand--inner': isInner(value)
+              'time-picker-clock__hand--inner': isInner(value),
             }"
           />
           <span
@@ -31,7 +31,9 @@
             class="time-picker-clock__item"
             :class="{
               'time-picker-clock__item--active': v === displayedValue,
-             'time-picker-clock__item--disabled': props.disabled || (props.disabledValues && props.disabledValues.includes(v))
+              'time-picker-clock__item--disabled':
+                props.disabled ||
+                (props.disabledValues && props.disabledValues.includes(v)),
             }"
             :style="getTransform(v)"
           >
@@ -48,7 +50,6 @@
     </div>
   </div>
 </template>
-
 
 <script lang="ts" setup>
 import { computed, reactive, ref, watch } from "vue";
@@ -81,7 +82,7 @@ const state = reactive({
   inputValue: props.value,
   isDragging: false,
   valueOnMouseDown: null as number | null,
-  valueOnMouseUp: null as number | null
+  valueOnMouseUp: null as number | null,
 });
 
 const values = computed(() => {
@@ -115,7 +116,7 @@ const clockHandStyle = computed(() => ({
       ? props.disabled
         ? "#8d7d7d"
         : props.color
-      : undefined
+      : undefined,
 }));
 
 const displayedValue = computed(() =>
@@ -138,7 +139,7 @@ const getPosition = (value: number) => {
       handScale(value),
     y:
       -Math.cos((value - props.min) * degrees.value + rotateRadians) *
-      handScale(value)
+      handScale(value),
   };
 };
 
@@ -152,7 +153,7 @@ const getTransform = (i: number) => {
           : props.color
         : undefined,
     left: `${50 + x * 50}%`,
-    top: `${50 + y * 50}%`
+    top: `${50 + y * 50}%`,
   };
 };
 
@@ -206,12 +207,16 @@ const onDragMove = (e: MouseEvent | TouchEvent) => {
     const handAngle = Math.round(angle(center, coords) - 0 + 360) % 360;
     const insideClick =
       selectingHour.value &&
-      euclidean(center, coords) < (innerWidth + innerWidth * innerRadiusScale) / 4;
+      euclidean(center, coords) <
+        (innerWidth + innerWidth * innerRadiusScale) / 4;
     const checksCount = Math.ceil(15 / degreesPerUnit.value);
 
     let value;
     for (let i = 0; i < checksCount; i++) {
-      let newValue = angleToValue(handAngle + i * degreesPerUnit.value, insideClick);
+      let newValue = angleToValue(
+        handAngle + i * degreesPerUnit.value,
+        insideClick
+      );
       if (props.disabledValues && props.disabledValues.includes(newValue)) {
         continue;
       }

--- a/src/components/timePickerClock.vue
+++ b/src/components/timePickerClock.vue
@@ -31,7 +31,7 @@
             class="time-picker-clock__item"
             :class="{
               'time-picker-clock__item--active': v === displayedValue,
-              'time-picker-clock__item--disabled': props.disabled
+             'time-picker-clock__item--disabled': props.disabled || (props.disabledValues && props.disabledValues.includes(v))
             }"
             :style="getTransform(v)"
           >
@@ -48,6 +48,7 @@
     </div>
   </div>
 </template>
+
 
 <script lang="ts" setup>
 import { computed, reactive, ref, watch } from "vue";
@@ -73,6 +74,7 @@ const props = defineProps<{
   min: number;
   max: number;
   step: number;
+  disabledValues?: number[];
 }>();
 
 const state = reactive({
@@ -184,6 +186,9 @@ const update = (value: number) => {
 };
 
 const setMouseDownValue = (value: number) => {
+  if (props.disabledValues && props.disabledValues.includes(value)) {
+    return;
+  }
   if (state.valueOnMouseDown === null) state.valueOnMouseDown = value;
   state.valueOnMouseUp = value;
   update(value);
@@ -201,14 +206,16 @@ const onDragMove = (e: MouseEvent | TouchEvent) => {
     const handAngle = Math.round(angle(center, coords) - 0 + 360) % 360;
     const insideClick =
       selectingHour.value &&
-      euclidean(center, coords) <
-        (innerWidth + innerWidth * innerRadiusScale) / 4;
+      euclidean(center, coords) < (innerWidth + innerWidth * innerRadiusScale) / 4;
     const checksCount = Math.ceil(15 / degreesPerUnit.value);
-    let value;
 
+    let value;
     for (let i = 0; i < checksCount; i++) {
-      value = angleToValue(handAngle + i * degreesPerUnit.value, insideClick);
-      return setMouseDownValue(value);
+      let newValue = angleToValue(handAngle + i * degreesPerUnit.value, insideClick);
+      if (props.disabledValues && props.disabledValues.includes(newValue)) {
+        continue;
+      }
+      return setMouseDownValue(newValue);
     }
   }
 };
@@ -238,7 +245,6 @@ watch(
 </script>
 
 <style lang="sass" scoped>
-
 .time-picker-clock
   background-color: #eee
   font-family: Roboto
@@ -251,7 +257,7 @@ watch(
   flex: 1 0 auto
 
   &__item--disabled
-    color: pink
+    color: #bababa
 
     &.time-picker-clock__item--active
       color: purple


### PR DESCRIPTION
Hi Matija,

This might be useful—I’ve added properties to disable specific hours, minutes, and seconds as arrays.

![image](https://github.com/user-attachments/assets/06e7d55b-5f6b-43a6-9b37-ed25cf977afe)
![image](https://github.com/user-attachments/assets/489fd5db-aa2a-41b1-8856-bac16ac30c5d)
![image](https://github.com/user-attachments/assets/e90b0c28-a01e-4926-810d-d9839c632163)
